### PR TITLE
adding missing dependency

### DIFF
--- a/rpm/fuse-overlayfs.spec.template
+++ b/rpm/fuse-overlayfs.spec.template
@@ -11,6 +11,7 @@ BuildRequires: autoconf automake
 BuildRequires: git
 BuildRequires: gcc
 BuildRequires: fuse3-devel
+Requires: fuse3
 
 %description
 fuse-overlayfs is a FUSE overlayfs implementation.


### PR DESCRIPTION
On a freshly installed system (F28) installing `fuse-overlayfs` package is insufficient to run it:
```
fuse-overlayfs -o lowerdir=lowerdir -o upperdir=upperdir -o workdir=workdir mountdir
UID=unchanged
GID=unchanged
UPPERDIR=/home/core/fuse/upperdir
WORKDIR=workdir
LOWERDIR=lowerdir
MOUNTPOINT=mountdir
fuse: failed to exec fusermount3: No such file or directory
```
```
dnf provides fusermount3
Last metadata expiration check: 0:53:07 ago on Mon 15 Oct 2018 06:15:49 PM UTC.
fuse3-3.2.1-11.fc28.x86_64 : File System in Userspace (FUSE) v3 utilitie
Repo        : fedora
Matched from:
Filename    : /usr/bin/fusermount3
```
This small change adds `fuse3` as a `fuse-overlayfs`  dependency.